### PR TITLE
fix: Nicer looking highlights

### DIFF
--- a/src/content/time-warnings.ts
+++ b/src/content/time-warnings.ts
@@ -35,13 +35,11 @@ export function ensureTimeWarningStyles(root: Document = document) {
   style.id = STYLES_ID;
   style.textContent = `
     td.adv-time-warn {
-      outline: 6px solid orange;
-      outline-offset: -6px;
+      background-color: orange !important;
     }
 
     td.adv-missing-event-warn {
-      outline: 6px solid red;
-      outline-offset: -6px;
+      background-color: red !important;
     }
   `;
   root.head.appendChild(style);


### PR DESCRIPTION
Only added the style code to make the nicer looking highlights.

I did not add the additional code to Also highlight Columns with missing time.

We may want to also add code so the missing event is highlighted when that row is not in focus.


Right now seems to only get highlighted when that row is in focus.

Here is what highlights will look like

<img width="1109" height="449" alt="image" src="https://github.com/user-attachments/assets/d8fe48b6-3ce4-4998-9e6f-e770259fbb82" />
